### PR TITLE
Fix for Issue #16 - zones and overlays won't be force-enabled during rendering if respective settings are set

### DIFF
--- a/Source/MapComponents/MapComponent_RenderManager.cs
+++ b/Source/MapComponents/MapComponent_RenderManager.cs
@@ -196,12 +196,16 @@ namespace ProgressRenderer
                 showTemperatureOverlay = settings.showTemperatureOverlay
             };
 
-            Find.PlaySettings.showZones = PRModSettings.renderZones;
-            Find.PlaySettings.showRoofOverlay = PRModSettings.renderOverlays;
-            Find.PlaySettings.showFertilityOverlay = PRModSettings.renderOverlays;
-            Find.PlaySettings.showTerrainAffordanceOverlay = PRModSettings.renderOverlays;
-            Find.PlaySettings.showPollutionOverlay = PRModSettings.renderOverlays;
-            Find.PlaySettings.showTemperatureOverlay = PRModSettings.renderOverlays;
+            if (!PRModSettings.renderZones)
+                Find.PlaySettings.showZones = false;
+            if (!PRModSettings.renderOverlays)
+            {
+                Find.PlaySettings.showRoofOverlay = false;
+                Find.PlaySettings.showFertilityOverlay = false;
+                Find.PlaySettings.showTerrainAffordanceOverlay = false;
+                Find.PlaySettings.showPollutionOverlay = false;
+                Find.PlaySettings.showTemperatureOverlay = false;
+            }
 
             //TODO: Hide plans
             //TODO: Hide blueprints


### PR DESCRIPTION
Previously when enabling zones/overlays for rendering, they would all be shown during the render, causing quite a mess. 
This way they only get rendered if they were active when the rendering started and are otherwise not shown.