### PR TITLE
Several fixes and improvements

### DIFF
--- a/Common/Languages/English/Keyed/All.xml
+++ b/Common/Languages/English/Keyed/All.xml
@@ -60,7 +60,7 @@
 	<LPR_SettingsJPGQualityAdjustment>Quality adjustment</LPR_SettingsJPGQualityAdjustment>
 	<LPR_JPGQualityAdjustment_Manual>Manual</LPR_JPGQualityAdjustment_Manual>
 	<LPR_JPGQualityAdjustment_Automatic>Automatic</LPR_JPGQualityAdjustment_Automatic>
-	<LPR_RenderSizeLabel>Target render size for this map</LPR_RenderSizeLabel>
+	<LPR_RenderSizeLabel>Target render size for this world</LPR_RenderSizeLabel>
 	<LPR_RenderSizeDescription>JPG quality will automatically be adjusted after each render to be near this target, preferencing quality slightly.</LPR_RenderSizeDescription>
 	<LPR_JPGQualityLabel>JPG Quality</LPR_JPGQualityLabel>
 	<LPR_JPGQualityDescription>Higher values correspond to higher image quality, lower values correspond to smaller image size</LPR_JPGQualityDescription>

--- a/Source/GameComponents/GameComponentProgressManager.cs
+++ b/Source/GameComponents/GameComponentProgressManager.cs
@@ -18,7 +18,7 @@ namespace ProgressRenderer
         // variables related to automatic quality adjustment
 
         public static JPGQualityAdjustmentSetting defaultJPGQualityAdjustment = JPGQualityAdjustmentSetting.Manual;
-        public static int defaultRenderSize = 25;
+        public static int defaultRenderSize = 20;
         public static int defaultJPGQuality_WORLD = 93;
         public static int defaultpixelsPerCell_WORLD = 32;
 

--- a/Source/MapComponents/MapComponent_RenderManager.cs
+++ b/Source/MapComponents/MapComponent_RenderManager.cs
@@ -580,6 +580,11 @@ namespace ProgressRenderer
 
             if (GameComponentProgressManager.JPGQualitySteady)
             {
+                if (PRModSettings.JPGQualityInitialize)
+                {
+                    renderMessage += "Target size reached, initialization ended, ";
+                    PRModSettings.JPGQualityInitialize = false;
+                }
                 Messages.Message(renderMessage, MessageTypeDefOf.CautionInput, false);
                 return;
             }
@@ -597,7 +602,7 @@ namespace ProgressRenderer
 
         private string CalculateQuality(float renderSize, string renderMessage)
         {
-            // render is too large, let's take a closer look
+            // if render is too large, let's take a closer look
             if (renderSize > GameComponentProgressManager.renderSize)
             {
                 if (GameComponentProgressManager.JPGQuality_WORLD > 0)
@@ -608,18 +613,18 @@ namespace ProgressRenderer
                         GameComponentProgressManager.JPGQuality_WORLD -= 1;
                         renderMessage += "JPG quality decreased to " +
                                          GameComponentProgressManager.JPGQuality_WORLD +
-                                         "% · render size: " + renderSize + " Target: " +
+                                         "% · render size: " + renderSize.ToString("0.00") + " Target: " +
                                          GameComponentProgressManager.renderSize;
                     }
                     // if quality was going up and then down again, we have found the target quality
                     else if (!GameComponentProgressManager.JPGQualitySteady)
                     {
                         GameComponentProgressManager.JPGQualitySteady = true;
-                        GameComponentProgressManager.JPGQualityTopMargin = Convert.ToInt32(renderSize);
+                        GameComponentProgressManager.JPGQualityTopMargin = Convert.ToInt32(Math.Ceiling(renderSize));
                         PRModSettings.JPGQualityInitialize = false; // if initializing, end it now
                         renderMessage += "JPG quality target reached (" +
                                          GameComponentProgressManager.JPGQuality_WORLD +
-                                         "%) · render size: " + renderSize + " Target: " +
+                                         "%) · render size: " + renderSize.ToString("0.00") + " Target: " +
                                          GameComponentProgressManager.renderSize;
                     }
 
@@ -636,7 +641,7 @@ namespace ProgressRenderer
                 if (GameComponentProgressManager.JPGQuality_WORLD < 100)
                 {
                     GameComponentProgressManager.JPGQuality_WORLD += 1;
-                    GameComponentProgressManager.JPGQualityBottomMargin = Convert.ToInt32(renderSize);
+                    GameComponentProgressManager.JPGQualityBottomMargin = Convert.ToInt32(Math.Floor(renderSize));
                     renderMessage += "JPG quality increased to " +
                                      GameComponentProgressManager.JPGQuality_WORLD +
                                      "% · render size: " + renderSize + " Target: " +

--- a/Source/Mod/PRModSettings.cs
+++ b/Source/Mod/PRModSettings.cs
@@ -252,6 +252,7 @@ namespace ProgressRenderer
             Scribe_Values.Look(ref smoothRenderAreaSteps, "smoothRenderAreaSteps", DefaultSmoothRenderAreaSteps);
             Scribe_Values.Look(ref whichInterval, "whichInterval", RenderIntervalHelper.Intervals.IndexOf(DefaultInterval));
             Scribe_Values.Look(ref timeOfDay, "timeOfDay", DefaultTimeOfDay);
+            Scribe_Values.Look(ref encoding, "encodingFormat", DefaultEncoding);
             Scribe_Values.Look(ref JPGQuality, "JPGQuality", DefaultJPGQuality);
             Scribe_Values.Look(ref pixelsPerCell, "pixelsPerCell", DefaultpixelsPerCell);
             Scribe_Values.Look(ref scaleOutputImage, "scaleOutputImage", DefaultScaleOutputImage);


### PR DESCRIPTION
PNG setting was not saved
Prevent init loop when already steady
default file size changed from 25 to 20
prevent rounding causing occasional bouncing by using math.ceiling/floor
filesize in messages now shown as 0.00