### PR TITLE
Add option to the mod menu for compatibillity

### DIFF
--- a/Common/Languages/English/Keyed/All.xml
+++ b/Common/Languages/English/Keyed/All.xml
@@ -36,6 +36,8 @@
 	<LPR_RenderFeedback_Window>Popup</LPR_RenderFeedback_Window>
 	<LPR_SettingsRenderSettingsLabel>Render settings</LPR_SettingsRenderSettingsLabel>
 	<LPR_SettingsRenderSettingsDescription>Configure some optional graphical elements that should be included in the rendered images. The map will always be rendered while some temporary parts like your current selection, targeters or ui text and the mouse cursor are never included.</LPR_SettingsRenderSettingsDescription>
+	<LPR_SettingsRenderNonPlayerHomes>Non-PlayerHome Maps</LPR_SettingsRenderNonPlayerHomes>
+	<LPR_SettingsRenderNonPlayerHomesDescription>Enable this to also render maps which aren't classified as player homes.</LPR_SettingsRenderNonPlayerHomesDescription>
 	<LPR_SettingsRenderDesignationsLabel>Designations</LPR_SettingsRenderDesignationsLabel>
 	<LPR_SettingsRenderDesignationsDescription>Enable this when the rendered images should show designators. For example the mining, smoothing and plant cut designators.</LPR_SettingsRenderDesignationsDescription>
 	<LPR_SettingsRenderThingIconsLabel>Thing icons</LPR_SettingsRenderThingIconsLabel>
@@ -82,4 +84,6 @@
 	<LPR_FileNamePattern_BothTmpCopy>Both (numbered copy in tmp subdir)</LPR_FileNamePattern_BothTmpCopy>
 	<LPR_SettingsCreateSubdirsLabel>Create subdirectories for each world</LPR_SettingsCreateSubdirsLabel>
 	<LPR_SettingsCreateSubdirsDescription>Enable this if you want rendered images to be stored in subdirectories for each game/world by the world seed.</LPR_SettingsCreateSubdirsDescription>
+	<LPR_SettingsUseMapNameInstead>Use map name instead of world tile</LPR_SettingsUseMapNameInstead>
+	<LPR_SettingsUseMapNameInsteadDescription>Enable this if you want the map name to be used in place of the map's world tile ID</LPR_SettingsUseMapNameInsteadDescription>
 </LanguageData>

--- a/Common/Languages/English/Keyed/All.xml
+++ b/Common/Languages/English/Keyed/All.xml
@@ -36,7 +36,7 @@
 	<LPR_RenderFeedback_Window>Popup</LPR_RenderFeedback_Window>
 	<LPR_SettingsRenderSettingsLabel>Render settings</LPR_SettingsRenderSettingsLabel>
 	<LPR_SettingsRenderSettingsDescription>Configure some optional graphical elements that should be included in the rendered images. The map will always be rendered while some temporary parts like your current selection, targeters or ui text and the mouse cursor are never included.</LPR_SettingsRenderSettingsDescription>
-	<LPR_SettingsRenderNonPlayerHomes>Non-PlayerHome Maps</LPR_SettingsRenderNonPlayerHomes>
+	<LPR_SettingsRenderNonPlayerHomes>Non-colony maps</LPR_SettingsRenderNonPlayerHomes>
 	<LPR_SettingsRenderNonPlayerHomesDescription>Enable this to also render maps which aren't classified as player homes.</LPR_SettingsRenderNonPlayerHomesDescription>
 	<LPR_SettingsRenderDesignationsLabel>Designations</LPR_SettingsRenderDesignationsLabel>
 	<LPR_SettingsRenderDesignationsDescription>Enable this when the rendered images should show designators. For example the mining, smoothing and plant cut designators.</LPR_SettingsRenderDesignationsDescription>

--- a/Source/MapComponents/MapComponent_RenderManager.cs
+++ b/Source/MapComponents/MapComponent_RenderManager.cs
@@ -82,7 +82,7 @@ namespace ProgressRenderer
 
             // Check for rendering
             // Only render player home maps
-            if (!map.IsPlayerHome)
+            if (!map.IsPlayerHome && !PRModSettings.renderNonPlayerHomes)
             {
                 return;
             }
@@ -733,13 +733,15 @@ namespace ProgressRenderer
             var quadrum = MoreGenDate.QuadrumInteger(tick, longitude);
             var day = GenDate.DayOfQuadrum(tick, longitude) + 1;
             var hour = GenDate.HourInteger(tick, longitude);
-            return "rimworld-" + Find.World.info.seedString + "-" + map.Tile + "-" + year + "-" + quadrum + "-" +
+            string mapName = PRModSettings.useMapNameInstead ? map.ToString() : map.Tile.ToString();
+            return "rimworld-" + Find.World.info.seedString + "-" + mapName + "-" + year + "-" + quadrum + "-" +
                    ((day < 10) ? "0" : "") + day + "-" + ((hour < 10) ? "0" : "") + hour;
         }
 
         private string CreateImageNameNumbered()
         {
-            return "rimworld-" + Find.World.info.seedString + "-" + map.Tile + "-" +
+            string mapName = PRModSettings.useMapNameInstead ? map.ToString() : map.Tile.ToString();
+            return "rimworld-" + Find.World.info.seedString + "-" + mapName + "-" +
                    lastRenderedCounter.ToString("000000");
         }
     }

--- a/Source/Mod/PRModSettings.cs
+++ b/Source/Mod/PRModSettings.cs
@@ -11,6 +11,7 @@ namespace ProgressRenderer
     public class PRModSettings : ModSettings
     {
         private static RenderFeedback DefaultRenderFeedback = RenderFeedback.Window;
+        private static bool DefaultRenderNonPlayerHomes = false;
         private static bool DefaultRenderDesignations = false;
         private static bool DefaultRenderThingIcons = false;
         private static bool DefaultRenderGameConditions = true;
@@ -49,6 +50,7 @@ namespace ProgressRenderer
         public static int outputImageFixedHeight = DefaultOutputImageFixedHeight;
         public static string exportPath;
         public static bool createSubdirs = DefaultCreateSubdirs;
+        public static bool useMapNameInstead = false; 
         public static FileNamePattern fileNamePattern = DefaultFileNamePattern;
 
         private static string outputImageFixedHeightBuffer;
@@ -56,6 +58,8 @@ namespace ProgressRenderer
         public static bool DoMigrations { get; internal set; } = true;
         public static bool migratedOutputImageSettings = false;
         public static bool migratedInterval = false;
+
+        public static bool renderNonPlayerHomes = false;
 
         public PRModSettings() : base()
         {
@@ -121,6 +125,7 @@ namespace ProgressRenderer
             ls.CheckboxLabeled("LPR_SettingsRenderWeatherLabel".Translate(), ref renderWeather, "LPR_SettingsRenderWeatherDescription".Translate());
             ls.CheckboxLabeled("LPR_SettingsRenderZonesLabel".Translate(), ref renderZones, "LPR_SettingsRenderZonesDescription".Translate());
             ls.CheckboxLabeled("LPR_SettingsRenderOverlaysLabel".Translate(), ref renderOverlays, "LPR_SettingsRenderOverlaysDescription".Translate());
+            ls.CheckboxLabeled("LPR_SettingsRenderNonPlayerHomes".Translate(), ref renderNonPlayerHomes, "LPR_SettingsRenderNonPlayerHomesDescription".Translate());
             ls.GapLine();
 
             ls.Gap();
@@ -219,6 +224,7 @@ namespace ProgressRenderer
 
             ls.Gap();
             ls.CheckboxLabeled("LPR_SettingsCreateSubdirsLabel".Translate(), ref createSubdirs, "LPR_SettingsCreateSubdirsDescription".Translate());
+            ls.CheckboxLabeled("LPR_SettingsUseMapNameInstead".Translate(), ref useMapNameInstead, "LPR_SettingsUseMapNameInsteadDescription".Translate());
             backupAnchor = Text.Anchor;
             Text.Anchor = TextAnchor.MiddleLeft;
             if (ls.ButtonTextLabeled("LPR_SettingsFileNamePatternLabel".Translate(), ("LPR_FileNamePattern_" + fileNamePattern).Translate()))
@@ -244,6 +250,7 @@ namespace ProgressRenderer
             base.ExposeData();
             Scribe_Values.Look(ref renderFeedback, "renderFeedback", DefaultRenderFeedback);
             Scribe_Values.Look(ref renderDesignations, "renderDesignations", DefaultRenderDesignations);
+            Scribe_Values.Look(ref renderNonPlayerHomes, "renderNonPlayerHomes", DefaultRenderNonPlayerHomes);
             Scribe_Values.Look(ref renderThingIcons, "renderThingIcons", DefaultRenderThingIcons);
             Scribe_Values.Look(ref renderGameConditions, "renderGameConditions", DefaultRenderGameConditions);
             Scribe_Values.Look(ref renderWeather, "renderWeather", DefaultRenderWeather);
@@ -259,6 +266,7 @@ namespace ProgressRenderer
             Scribe_Values.Look(ref outputImageFixedHeight, "outputImageFixedHeight", DefaultOutputImageFixedHeight);
             Scribe_Values.Look(ref exportPath, "exportPath", DesktopPath);
             Scribe_Values.Look(ref createSubdirs, "createSubdirs", DefaultCreateSubdirs);
+            Scribe_Values.Look(ref useMapNameInstead, "useMapNameInstead", false);
             Scribe_Values.Look(ref fileNamePattern, "fileNamePattern", DefaultFileNamePattern);
             Scribe_Values.Look(ref migratedOutputImageSettings, "migratedOutputImageSettings", false, true);
             Scribe_Values.Look(ref migratedInterval, "migratedInterval", false, true);


### PR DESCRIPTION
Users might want to render maps which aren't technically player homes. I know I do!

I've been using DeepRim for awhile and couldn't get it to work and render images for underground maps, so I looked in the source to find out why. Turns out to be a single if-statement which returns -_-.
Now it'll check for a mod config option which allows it to capture images of other maps.