### PR TITLE
Added reflection to 4 patches for compatibility with 1.6

### DIFF
--- a/Progress-Renderer.sln
+++ b/Progress-Renderer.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Progress-Renderer", "Progress-Renderer.csproj", "{EA4F6D24-B346-4264-A6BE-4588ECD4F748}"
 EndProject
@@ -13,8 +13,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Debug|Any CPU.ActiveCfg = Release|Any CPU
+		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA4F6D24-B346-4264-A6BE-4588ECD4F748}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/Source/Harmony_Patches/Harmony_AreaManager.cs
+++ b/Source/Harmony_Patches/Harmony_AreaManager.cs
@@ -3,21 +3,19 @@ using Verse;
 
 namespace ProgressRenderer
 {
-
     [HarmonyPatch(typeof(AreaManager))]
     [HarmonyPatch("AreaManagerUpdate")]
     public class Harmony_AreaManager_AreaManagerUpdate
     {
-
-        public static bool Prefix(Map map)
+        public static bool Prefix(AreaManager __instance)
         {
+            Map map = __instance.map; // Access the map field from AreaManager
+
             if (map.GetComponent<MapComponent_RenderManager>().Rendering)
             {
                 return false;
             }
             return true;
         }
-
     }
-    
 }

--- a/Source/Harmony_Patches/Harmony_AreaManager.cs
+++ b/Source/Harmony_Patches/Harmony_AreaManager.cs
@@ -1,5 +1,6 @@
 ﻿using HarmonyLib;
 using Verse;
+using System.Reflection;
 
 namespace ProgressRenderer
 {
@@ -9,13 +10,18 @@ namespace ProgressRenderer
     {
         public static bool Prefix(AreaManager __instance)
         {
-            Map map = __instance.map; // Access the map field from AreaManager
-
-            if (map.GetComponent<MapComponent_RenderManager>().Rendering)
+            try
             {
-                return false;
+                Map map = __instance.map;
+                if (map != null && map.GetComponent<MapComponent_RenderManager>()?.Rendering == true)
+                    return false;
+                return true;
             }
-            return true;
+            catch (System.Exception ex)
+            {
+                Log.Warning($"[ProgressRenderer] AreaManagerUpdate patch error: {ex.Message}");
+                return true;
+            }
         }
     }
 }

--- a/Source/Harmony_Patches/Harmony_DeepResourceGrid.cs
+++ b/Source/Harmony_Patches/Harmony_DeepResourceGrid.cs
@@ -10,15 +10,19 @@ namespace ProgressRenderer
     {
         public static bool Prefix(DeepResourceGrid __instance)
         {
-            // Use reflection to get the private map field
-            var mapField = typeof(DeepResourceGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
-            Map map = (Map)mapField.GetValue(__instance);
-
-            if (map.GetComponent<MapComponent_RenderManager>().Rendering)
+            try
             {
-                return false;
+                var mapField = typeof(DeepResourceGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+                Map map = (Map)mapField?.GetValue(__instance);
+                if (map != null && map.GetComponent<MapComponent_RenderManager>()?.Rendering == true)
+                    return false;
+                return true;
             }
-            return true;
+            catch (System.Exception ex)
+            {
+                Log.Warning($"[ProgressRenderer] DeepResourceGridUpdate patch error: {ex.Message}");
+                return true;
+            }
         }
     }
 }

--- a/Source/Harmony_Patches/Harmony_DeepResourceGrid.cs
+++ b/Source/Harmony_Patches/Harmony_DeepResourceGrid.cs
@@ -1,23 +1,24 @@
 ﻿using HarmonyLib;
 using Verse;
+using System.Reflection;
 
 namespace ProgressRenderer
 {
-
     [HarmonyPatch(typeof(DeepResourceGrid))]
     [HarmonyPatch("DeepResourceGridUpdate")]
     public class Harmony_DeepResourceGrid_DeepResourceGridUpdate
     {
-
-        public static bool Prefix(Map map)
+        public static bool Prefix(DeepResourceGrid __instance)
         {
+            // Use reflection to get the private map field
+            var mapField = typeof(DeepResourceGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+            Map map = (Map)mapField.GetValue(__instance);
+
             if (map.GetComponent<MapComponent_RenderManager>().Rendering)
             {
                 return false;
             }
             return true;
         }
-
     }
-
 }

--- a/Source/Harmony_Patches/Harmony_DesignationManager.cs
+++ b/Source/Harmony_Patches/Harmony_DesignationManager.cs
@@ -1,6 +1,7 @@
 ﻿using HarmonyLib;
 using Verse;
 using System.Reflection;
+using RimWorld;
 
 namespace ProgressRenderer
 {
@@ -10,15 +11,19 @@ namespace ProgressRenderer
     {
         public static bool Prefix(DesignationManager __instance)
         {
-            // Use reflection to access the private 'map' field
-            var mapField = typeof(DesignationManager).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
-            Map map = (Map)mapField.GetValue(__instance);
-
-            if (map != null && map.GetComponent<MapComponent_RenderManager>().Rendering)
+            try
             {
-                return false;
+                var mapField = typeof(DesignationManager).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+                Map map = (Map)mapField?.GetValue(__instance);
+                if (map != null && map.GetComponent<MapComponent_RenderManager>()?.Rendering == true)
+                    return false;
+                return true;
             }
-            return true;
+            catch (System.Exception ex)
+            {
+                Log.Warning($"[ProgressRenderer] DrawDesignations patch error: {ex.Message}");
+                return true;
+            }
         }
     }
 }

--- a/Source/Harmony_Patches/Harmony_DesignationManager.cs
+++ b/Source/Harmony_Patches/Harmony_DesignationManager.cs
@@ -1,23 +1,24 @@
 ﻿using HarmonyLib;
 using Verse;
+using System.Reflection;
 
 namespace ProgressRenderer
 {
-
     [HarmonyPatch(typeof(DesignationManager))]
     [HarmonyPatch("DrawDesignations")]
     public class Harmony_DesignationManager_DrawDesignations
     {
-
-        public static bool Prefix(DesignationManager instance)
+        public static bool Prefix(DesignationManager __instance)
         {
-            if (!PrModSettings.RenderDesignations && instance.map.GetComponent<MapComponent_RenderManager>().Rendering)
+            // Use reflection to access the private 'map' field
+            var mapField = typeof(DesignationManager).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+            Map map = (Map)mapField.GetValue(__instance);
+
+            if (map != null && map.GetComponent<MapComponent_RenderManager>().Rendering)
             {
                 return false;
             }
             return true;
         }
-
     }
-    
 }

--- a/Source/Harmony_Patches/Harmony_RoofGrid.cs
+++ b/Source/Harmony_Patches/Harmony_RoofGrid.cs
@@ -1,23 +1,26 @@
 ﻿using HarmonyLib;
 using Verse;
+using System.Reflection;
 
 namespace ProgressRenderer
 {
-
     [HarmonyPatch(typeof(RoofGrid))]
     [HarmonyPatch("RoofGridUpdate")]
     public class Harmony_RoofGrid_RoofGridUpdate
     {
-
-        public static bool Prefix(Map map)
+        public static bool Prefix(RoofGrid __instance)
         {
-            if (map.GetComponent<MapComponent_RenderManager>().Rendering)
+            // Use reflection to get the private 'map' field
+            var mapField = typeof(RoofGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+            Map map = (Map)mapField.GetValue(__instance);
+
+            if (map != null && map.GetComponent<MapComponent_RenderManager>().Rendering)
             {
+                // Skip the original method if rendering is in progress
                 return false;
             }
+            // Allow the original method to run
             return true;
         }
-
     }
-
 }

--- a/Source/Harmony_Patches/Harmony_RoofGrid.cs
+++ b/Source/Harmony_Patches/Harmony_RoofGrid.cs
@@ -10,17 +10,19 @@ namespace ProgressRenderer
     {
         public static bool Prefix(RoofGrid __instance)
         {
-            // Use reflection to get the private 'map' field
-            var mapField = typeof(RoofGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
-            Map map = (Map)mapField.GetValue(__instance);
-
-            if (map != null && map.GetComponent<MapComponent_RenderManager>().Rendering)
+            try
             {
-                // Skip the original method if rendering is in progress
-                return false;
+                var mapField = typeof(RoofGrid).GetField("map", BindingFlags.NonPublic | BindingFlags.Instance);
+                Map map = (Map)mapField?.GetValue(__instance);
+                if (map != null && map.GetComponent<MapComponent_RenderManager>()?.Rendering == true)
+                    return false;
+                return true;
             }
-            // Allow the original method to run
-            return true;
+            catch (System.Exception ex)
+            {
+                Log.Warning($"[ProgressRenderer] RoofGridUpdate patch error: {ex.Message}");
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
Changed AreaManagerUpdate patch to use AreaManager __instance and access the map via __instance.map

Changed DeepResourceGridUpdate patch to use DeepResourceGrid __instance and access the map via reflection on the private map field

Changed DrawDesignations patch to use DesignationManager __instance and access the map via reflection on the private map field

Added null checks and warning feedback on exceptions