### PR TITLE
Added PlanningExtended support

### DIFF
--- a/Progress-Renderer.csproj
+++ b/Progress-Renderer.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Source\Harmony_Patches\Harmony_OptionListingUtility.cs" />
     <Compile Include="Source\Harmony_Patches\Harmony_OverlayDrawer.cs" />
     <Compile Include="Source\Harmony_Patches\Harmony_OverlayDrawHandler.cs" />
+    <Compile Include="Source\Harmony_Patches\Harmony_PlanDesignation_DesignationDraw.cs" />
     <Compile Include="Source\Harmony_Patches\Harmony_RoofGrid.cs" />
     <Compile Include="Source\Harmony_Patches\Harmony_ScreenshotModeHandler.cs" />
     <Compile Include="Source\Harmony_Patches\Harmony_Targeter.cs" />

--- a/Source/Harmony_Patches/Harmony_PlanDesignation_DesignationDraw.cs
+++ b/Source/Harmony_Patches/Harmony_PlanDesignation_DesignationDraw.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using HarmonyLib;
+using Verse;
+
+namespace ProgressRenderer
+{
+    [HarmonyPatch("PlanDesignation", nameof(Designation.DesignationDraw))]
+    public static class Harmony_PlanDesignation_DesignationDraw
+    {
+        public static bool Prefix(Designation __instance)
+        {
+            try
+            {
+                if (__instance.def == null) return true; 
+
+                var target = __instance.target;
+
+                Map map = target.HasThing ? target.Thing.MapHeld : Find.CurrentMap;
+
+                var renderManager = map?.GetComponent<MapComponent_RenderManager>();
+
+                if (renderManager?.Rendering == false)
+                    return true;
+
+                return PrModSettings.RenderDesignations;
+            }
+            catch (Exception ex)
+            {
+                // 1.6 UPDATE: Enhanced error reporting
+                Log.Error($"[ProgressRenderer] DesignationDraw patch error in 1.6: {ex}\n{ex.StackTrace}");
+                return true;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Due to a request, I've created this PR to add PlanningExtended support. Without this, all plannings designations are drawn regardless of the designation settings. I didn't add an extra setting just for PlanningExtended.