### PR TITLE
Fix Planning Extended mod detection

### DIFF
--- a/Source/Harmony_Patches/HarmonySetup.cs
+++ b/Source/Harmony_Patches/HarmonySetup.cs
@@ -11,7 +11,7 @@ namespace ProgressRenderer
         {
             var harmony = new Harmony("rimworld.neptimus7.progressrenderer");
 
-            if (LoadedModManager.RunningModsListForReading.Any(x => x.Name == "scherub.planningextended"))
+            if (LoadedModManager.RunningModsListForReading.Any(x => x.PackageId == "scherub.planningextended"))
                 harmony.PatchCategory("PlanningExtended");
 
             harmony.PatchAllUncategorized(Assembly.GetExecutingAssembly());


### PR DESCRIPTION
This PR fixes the patching logic for the Planning Extended mod. `"scherub.planningextended"` should be a package ID instead of a package name.